### PR TITLE
adjust font size and logo size

### DIFF
--- a/Gradeva/ViewModels/AuthManager.swift
+++ b/Gradeva/ViewModels/AuthManager.swift
@@ -107,7 +107,7 @@ class AuthManager: ObservableObject {
                 }
                 self.setLoading(false)
                 
-            case .failure(let error):
+            case .failure(_):
                 let appUser = AppUser(fromFirebaseUser: user)
                 
                 UserServices().handleFirstTimeLogin(user: appUser) { registrationResult in

--- a/Gradeva/Views/SignInView.swift
+++ b/Gradeva/Views/SignInView.swift
@@ -24,7 +24,7 @@ struct SignInView: View {
                 .fontWeight(.bold)
                 .padding(.bottom)
             
-            VStack(spacing: 16) {
+            VStack(spacing: 12) {
                 SignInWithAppleButton(
                     .signIn,
                     onRequest: auth.handleSignInWithAppleRequest,
@@ -37,12 +37,13 @@ struct SignInView: View {
                 .opacity(auth.isAuthLoading ? 0.5 : 1)
           
                 Button(action: auth.handleSignInWithGoogle) {
-                    HStack(spacing: 12) {
+                    HStack(spacing: 4) {
                         Image("g")
                             .resizable()
-                            .frame(width: 20, height: 20)
+                            .frame(width: 12, height: 12)
                         Text("Sign in with Google")
-                            .font(.system(size: 16, weight: .medium))
+                            .font(.headline)
+                            .fontWeight(.medium)
                             .foregroundColor(.primary)
                     }
                     .frame(width: 280, height: 45)


### PR DESCRIPTION
This pull request makes minor UI adjustments to the Google sign-in button and simplifies error handling in the authentication flow. The main changes are a more compact button design and the removal of the unused error variable in the authentication failure case.

UI improvements to Google sign-in:

* Reduced vertical spacing in the `VStack` containing sign-in buttons from 16 to 12 for a more compact layout (`SignInView.swift`).
* Decreased horizontal spacing within the Google sign-in button from 12 to 4, reduced the Google icon size, and updated the button text styling to use `.headline` with `.fontWeight(.medium)` (`SignInView.swift`).

Code simplification:

* Removed the unused `error` variable in the `.failure` case of the authentication result, streamlining error handling (`AuthManager.swift`).