### PR TITLE
implement demo environment, setup realtime listener

### DIFF
--- a/Gradeva/Models/UserModel.swift
+++ b/Gradeva/Models/UserModel.swift
@@ -14,6 +14,7 @@ class AppUser: Codable {
     var displayName: String?
     var email: String?
     var didCompleteOnboarding: Bool?
+    var didCompleteDemoOnboarding: Bool?
     var schoolId: String?
     var createdAt: Timestamp?
     var updatedAt: Timestamp?
@@ -24,6 +25,7 @@ class AppUser: Codable {
         displayName: String? = nil,
         email: String? = nil,
         didCompleteOnboarding: Bool? = nil,
+        didCompleteDemoOnboarding: Bool? = nil,
         schoolId: String? = nil,
         subjectIds: [String]? = nil
     ) {
@@ -31,6 +33,7 @@ class AppUser: Codable {
         self.displayName = displayName
         self.email = email
         self.didCompleteOnboarding = didCompleteOnboarding
+        self.didCompleteDemoOnboarding = didCompleteDemoOnboarding
         self.schoolId = schoolId
         self.subjectIds = subjectIds
     }
@@ -45,6 +48,7 @@ class AppUser: Codable {
         displayName: String? = nil,
         email: String? = nil,
         didCompleteOnboarding: Bool? = nil,
+        didCompleteDemoOnboarding: Bool? = nil,
         schoolId: String? = nil,
         subjectIds: [String]? = nil
     ) -> AppUser {
@@ -53,6 +57,7 @@ class AppUser: Codable {
             displayName: displayName ?? self.displayName,
             email: email ?? self.email,
             didCompleteOnboarding: didCompleteOnboarding ?? self.didCompleteOnboarding,
+            didCompleteDemoOnboarding: didCompleteDemoOnboarding ?? self.didCompleteDemoOnboarding,
             schoolId: schoolId ?? self.schoolId,
             subjectIds: subjectIds ?? self.subjectIds
         )

--- a/Gradeva/Services/UserServices.swift
+++ b/Gradeva/Services/UserServices.swift
@@ -85,4 +85,29 @@ class UserServices {
             }
         }
     }
+    
+    func startUserListener(uid: String, onUpdate: @escaping (Result<AppUser, Error>) -> Void) -> ListenerRegistration {
+        let userRef = db.collection("users").document(uid)
+        
+        return userRef.addSnapshotListener { documentSnapshot, error in
+            if let error = error {
+                onUpdate(.failure(error))
+                return
+            }
+            
+            guard let document = documentSnapshot else {
+                let error = NSError(domain: "", code: 0, userInfo: [NSLocalizedDescriptionKey: "Document not found"])
+                onUpdate(.failure(error))
+                return
+            }
+            
+            do {
+                let user = try document.data(as: AppUser.self)
+                onUpdate(.success(user))
+            } catch {
+                onUpdate(.failure(error))
+            }
+        }
+    }
+    
 }

--- a/Gradeva/Utils/AppLaunchManager.swift
+++ b/Gradeva/Utils/AppLaunchManager.swift
@@ -1,0 +1,31 @@
+//
+//  AppLaunchManager.swift
+//  Gradeva
+//
+//  Created by Claude on 20/08/25.
+//
+
+import Foundation
+import SwiftUI
+
+class AppLaunchManager: ObservableObject {
+    @Published var isFirstLaunch: Bool
+    
+    private let userDefaults = UserDefaults.standard
+    private let firstLaunchKey = "hasLaunchedBefore"
+    
+    static let shared = AppLaunchManager()
+    
+    init() {
+        let hasLaunchedBefore = userDefaults.bool(forKey: firstLaunchKey)
+        self.isFirstLaunch = !hasLaunchedBefore
+    }
+    
+    func markAppAsLaunched() {
+        userDefaults.set(true, forKey: firstLaunchKey)
+        
+        withAnimation {
+            isFirstLaunch = false
+        }
+    }
+}

--- a/Gradeva/ViewModels/AuthManager.swift
+++ b/Gradeva/ViewModels/AuthManager.swift
@@ -56,6 +56,14 @@ class AuthManager: ObservableObject {
         }
     }
     
+    private func setIsSignedIn(_ isSignedIn: Bool) {
+        DispatchQueue.main.async {
+            withAnimation {
+                self.isSignedIn = isSignedIn
+            }
+        }
+    }
+    
     func handleSignInWithAppleRequest(_ request: ASAuthorizationAppleIDRequest) {
         setLoading(true)
         appleSignInService.handleSignInWithAppleRequest(request)
@@ -94,8 +102,8 @@ class AuthManager: ObservableObject {
         do {
             stopUserListener()
             try Auth.auth().signOut()
+            self.setIsSignedIn(false)
             DispatchQueue.main.async {
-                self.isSignedIn = false
                 self.currentUser = nil
                 self.clearError()
             }
@@ -132,9 +140,7 @@ class AuthManager: ObservableObject {
             switch firestoreResult {
             case .success(let userData):
                 self.setUser(user: userData)
-                DispatchQueue.main.async {
-                    self.isSignedIn = true
-                }
+                self.setIsSignedIn(true)
                 self.setLoading(false)
                 
             case .failure(_):
@@ -144,9 +150,7 @@ class AuthManager: ObservableObject {
                     switch registrationResult {
                     case .success():
                         self.setUser(user: appUser)
-                        DispatchQueue.main.async {
-                            self.isSignedIn = true
-                        }
+                        self.setIsSignedIn(true)
                         self.setLoading(false)
                     case .failure(let error):
                         let authError = AuthError.userRegistrationFailed(error.localizedDescription)

--- a/Gradeva/ViewModels/AuthManager.swift
+++ b/Gradeva/ViewModels/AuthManager.swift
@@ -83,7 +83,9 @@ class AuthManager: ObservableObject {
     
     private func setLoading(_ loading: Bool) {
         DispatchQueue.main.async {
-            self.isAuthLoading = loading
+            withAnimation(.easeOut(duration: 0.5)) {
+                self.isAuthLoading = loading
+            }
         }
     }
     

--- a/Gradeva/ViewModels/RegistrationManager.swift
+++ b/Gradeva/ViewModels/RegistrationManager.swift
@@ -49,7 +49,7 @@ class RegistrationManager: ObservableObject {
         isLoading = true
         errorMessage = nil
         
-        let updatedUser = user.copy(schoolId: "demo-school")
+        let updatedUser = user.copy(didCompleteDemoOnboarding: true, schoolId: "demo-school")
         
         UserServices().updateUser(user: updatedUser) { [weak self] result in
             DispatchQueue.main.async {

--- a/Gradeva/ViewModels/RegistrationManager.swift
+++ b/Gradeva/ViewModels/RegistrationManager.swift
@@ -42,4 +42,27 @@ class RegistrationManager: ObservableObject {
                 }
             }
     }
+    
+    func registerToDemo() {
+        guard let user = auth.currentUser else { return }
+        
+        isLoading = true
+        errorMessage = nil
+        
+        let updatedUser = user.copy(schoolId: "demo-school")
+        
+        UserServices().updateUser(user: updatedUser) { [weak self] result in
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.isLoading = false
+                
+                switch result {
+                case .success:
+                    self.auth.currentUser = updatedUser
+                case .failure(let error):
+                    self.errorMessage = "Failed to register to demo school: \(error.localizedDescription)"
+                }
+            }
+        }
+    }
 }

--- a/Gradeva/ViewModels/SubjectsManager.swift
+++ b/Gradeva/ViewModels/SubjectsManager.swift
@@ -78,8 +78,7 @@ class SubjectsManager: ObservableObject {
                         
                         switch updateResult {
                         case .success:
-                            // Refresh user data to trigger reactivity
-                            self.auth.refreshCurrentUser()
+                            // User data will update automatically via Firestore listener
                             completion(.success(()))
                         case .failure(let error):
                             self.errorMessage = "Failed to update profile: \(error.localizedDescription)"
@@ -113,8 +112,7 @@ class SubjectsManager: ObservableObject {
                 
                 switch result {
                 case .success:
-                    // Refresh user data to trigger reactivity
-                    self.auth.refreshCurrentUser()
+                    // User data will update automatically via Firestore listener
                     completion(.success(()))
                 case .failure(let error):
                     completion(.failure(error))

--- a/Gradeva/Views/FirstLaunchWelcomeView.swift
+++ b/Gradeva/Views/FirstLaunchWelcomeView.swift
@@ -1,0 +1,64 @@
+//
+//  FirstLaunchWelcomeView.swift
+//  Gradeva
+//
+//  Created by Claude on 20/08/25.
+//
+
+import SwiftUI
+
+struct FirstLaunchWelcomeView: View {
+    let onLoginTapped: () -> Void
+    
+    var body: some View {
+        VStack(spacing: 40) {
+            Spacer()
+            
+            // App logo or icon
+            Image(systemName: "graduationcap.fill")
+                .font(.system(size: 80))
+                .foregroundColor(.accentColor)
+                .accessibilityHidden(true)
+            
+            // Welcome text
+            VStack(spacing: 16) {
+                Text("Welcome to Gradeva")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                    .accessibilityAddTraits(.isHeader)
+                
+                Text("Your comprehensive grading and analytics management solution")
+                    .font(.body)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.secondary)
+                    .accessibilityAddTraits(.isStaticText)
+            }
+            .padding(.horizontal, 24)
+            
+            Spacer()
+            
+            // Login button
+            Button(action: onLoginTapped) {
+                HStack {
+                    Text("Login")
+                    Image(systemName: "arrow.right")
+                        .accessibilityHidden(true)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 16)
+                .background(Color.accentColor)
+                .foregroundStyle(.white)
+                .clipShape(RoundedRectangle(cornerRadius: 16))
+            }
+            .accessibilityLabel("Login")
+            .accessibilityHint("Double tap to proceed to login screen")
+            .accessibilityAddTraits(.isButton)
+            .padding(.horizontal, 24)
+            .padding(.bottom, 40)
+        }
+    }
+}
+
+#Preview {
+    FirstLaunchWelcomeView(onLoginTapped: {})
+}

--- a/Gradeva/Views/FirstLaunchWelcomeView.swift
+++ b/Gradeva/Views/FirstLaunchWelcomeView.swift
@@ -25,14 +25,15 @@ struct FirstLaunchWelcomeView: View {
                 Text("Welcome to Gradeva")
                     .font(.largeTitle)
                     .fontWeight(.bold)
-                    .accessibilityAddTraits(.isHeader)
                 
                 Text("Your comprehensive grading and analytics management solution")
                     .font(.body)
                     .multilineTextAlignment(.center)
                     .foregroundColor(.secondary)
-                    .accessibilityAddTraits(.isStaticText)
             }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Welcome to Gradeva. Your comprehensive grading and analytics management solution.")
+            .accessibilityAddTraits(.isHeader)
             .padding(.horizontal, 24)
             
             Spacer()
@@ -53,9 +54,12 @@ struct FirstLaunchWelcomeView: View {
             .accessibilityLabel("Login")
             .accessibilityHint("Double tap to proceed to login screen")
             .accessibilityAddTraits(.isButton)
+            .frame(minHeight: 44) // Ensure minimum touch target size
             .padding(.horizontal, 24)
             .padding(.bottom, 40)
         }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Welcome screen")
     }
 }
 

--- a/Gradeva/Views/HomeView.swift
+++ b/Gradeva/Views/HomeView.swift
@@ -18,12 +18,12 @@ struct HomeView: View {
                     Text("Hello,")
                         .font(.title3)
                         .foregroundColor(.secondary)
-                    Text(user.email ?? "User")
+                    Text(user.displayName ?? user.email ?? "User")
                         .font(.title2)
                         .fontWeight(.semibold)
                 }
                 .accessibilityElement(children: .combine)
-                .accessibilityLabel("Welcome message for \(user.email ?? "User")")
+                .accessibilityLabel("Welcome message for \(user.displayName ?? user.email ?? "User")")
                 .accessibilityAddTraits(.isHeader)
                 
                 Text("UID: \(String(describing: user.id))")

--- a/Gradeva/Views/HomeView.swift
+++ b/Gradeva/Views/HomeView.swift
@@ -11,61 +11,65 @@ struct HomeView: View {
     @EnvironmentObject var auth: AuthManager
     @EnvironmentObject var navManager: NavManager
     
+    private var user: AppUser? {
+        auth.currentUser
+    }
+    
     var body: some View {
-        if let user = auth.currentUser {
-            VStack(spacing: 16) {
-                VStack(spacing: 8) {
-                    Text("Hello,")
-                        .font(.title3)
-                        .foregroundColor(.secondary)
-                    Text(user.displayName ?? user.email ?? "User")
-                        .font(.title2)
-                        .fontWeight(.semibold)
-                }
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel("Welcome message for \(user.displayName ?? user.email ?? "User")")
-                .accessibilityAddTraits(.isHeader)
-                
-                Text("UID: \(String(describing: user.id))")
-                    .font(.caption)
-                    .foregroundColor(.gray)
-                    .accessibilityLabel("User ID: \(String(describing: user.id))")
-                    .accessibilityAddTraits(.isStaticText)
-                
-                Spacer().frame(height: 24)
-                
-                VStack(spacing: 12) {
-                    Button(action: auth.signOut) {
-                        Text("Sign Out")
-                            .fontWeight(.semibold)
-                            .frame(maxWidth: .infinity)
-                            .padding()
-                            .background(Color.red)
-                            .foregroundColor(.white)
-                            .cornerRadius(8)
-                    }
-                    .padding(.horizontal)
-                    .accessibilityLabel("Sign Out")
-                    .accessibilityHint("Double tap to sign out of your account")
-                    .accessibilityAddTraits(.isButton)
-                    
-                    Button("Go to settings") {
-                        navManager.push(.settings)
-                    }
-                    .accessibilityLabel("Go to settings")
-                    .accessibilityHint("Double tap to open app settings")
-                    .accessibilityAddTraits(.isButton)
-                }
-                .accessibilityElement(children: .contain)
-                .accessibilityLabel("Action buttons")
-                
-                Spacer()
+        
+        VStack(spacing: 16) {
+            VStack(spacing: 8) {
+                Text("Hello,")
+                    .font(.title3)
+                    .foregroundColor(.secondary)
+                Text(user?.displayName ?? user?.email ?? "User")
+                    .font(.title2)
+                    .fontWeight(.semibold)
             }
-            .padding()
-            .navigationTitle("Dashboard")
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Welcome message for \(user?.displayName ?? user?.email ?? "User")")
+            .accessibilityAddTraits(.isHeader)
+            
+            Text("UID: \(String(describing: user?.id))")
+                .font(.caption)
+                .foregroundColor(.gray)
+                .accessibilityLabel("User ID: \(String(describing: user?.id))")
+                .accessibilityAddTraits(.isStaticText)
+            
+            Spacer().frame(height: 24)
+            
+            VStack(spacing: 12) {
+                Button(action: auth.signOut) {
+                    Text("Sign Out")
+                        .fontWeight(.semibold)
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.red)
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                }
+                .padding(.horizontal)
+                .accessibilityLabel("Sign Out")
+                .accessibilityHint("Double tap to sign out of your account")
+                .accessibilityAddTraits(.isButton)
+                
+                Button("Go to settings") {
+                    navManager.push(.settings)
+                }
+                .accessibilityLabel("Go to settings")
+                .accessibilityHint("Double tap to open app settings")
+                .accessibilityAddTraits(.isButton)
+            }
             .accessibilityElement(children: .contain)
-            .accessibilityLabel("Dashboard screen")
+            .accessibilityLabel("Action buttons")
+            
+            Spacer()
         }
+        .padding()
+        .navigationTitle("Dashboard")
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Dashboard screen")
+        
     }
 }
 

--- a/Gradeva/Views/MainTabView.swift
+++ b/Gradeva/Views/MainTabView.swift
@@ -1,0 +1,54 @@
+//
+//  MainTabView.swift
+//  Gradeva
+//
+//  Created by Claude on 20/08/25.
+//
+
+import SwiftUI
+
+struct MainTabView: View {
+    var body: some View {
+        TabView {
+            HomeView()
+                .tabItem {
+                    Label("Home", systemImage: "house")
+                        .accessibilityLabel("Home tab")
+                        .accessibilityHint("View dashboard and overview")
+                }
+            GradingView()
+                .tabItem {
+                    Label("Grading", systemImage: "pencil")
+                        .accessibilityLabel("Grading tab")
+                        .accessibilityHint("Grade student exams and assignments")
+                }
+            AnalyticsView()
+                .tabItem {
+                    Label("Analytics", systemImage: "chart.bar")
+                        .accessibilityLabel("Analytics tab")
+                        .accessibilityHint("View performance statistics and reports")
+                }
+            ProfileView()
+                .tabItem {
+                    Label("Profile", systemImage: "person")
+                        .accessibilityLabel("Profile tab")
+                        .accessibilityHint("Manage your account and settings")
+                }
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Main navigation tabs")
+        .navigationDestination(for: NavPath.self) { path in
+            switch path {
+            case .settings:
+                SettingsView()
+            case .grading(let examId):
+                GradingExamView(examId: examId)
+            }
+        }
+    }
+}
+
+#Preview {
+    MainTabView()
+        .environmentObject(NavManager())
+}

--- a/Gradeva/Views/MainView.swift
+++ b/Gradeva/Views/MainView.swift
@@ -12,6 +12,7 @@ import FirebaseAuth
 struct MainContentView: View {
     @ObservedObject private var auth = AuthManager.shared
     @StateObject private var navManager = NavManager()
+    @StateObject private var launchManager = AppLaunchManager.shared
     @State private var showSplashScreen = true
     
     var didCompleteOnboarding: Bool {
@@ -41,7 +42,13 @@ struct MainContentView: View {
                 SplashScreenView()
                     .transition(.blurReplace)
                     .onAppear(perform: hideSplashScreen)
-            // Signed-in  --> show HomeView
+            // First launch - show welcome screen with login button
+            } else if launchManager.isFirstLaunch {
+                FirstLaunchWelcomeView(onLoginTapped: {
+                    launchManager.markAppAsLaunched()
+                })
+                .transition(.blurReplace)
+            // Signed-in and has school --> show main content
             } else if auth.isSignedIn && isAssignedToSchool {
                 ZStack {
                     if !didCompleteOnboarding {

--- a/Gradeva/Views/MainView.swift
+++ b/Gradeva/Views/MainView.swift
@@ -41,20 +41,20 @@ struct MainContentView: View {
     
     var body: some View {
         NavigationStack(path: $navManager.paths) {
-            // Show splash screen on first launch for 1.5 seconds
-            if showSplashScreen {
-                SplashScreenView()
+            ZStack {
+                // Show splash screen on first launch for 1.5 seconds
+                if showSplashScreen {
+                    SplashScreenView()
+                        .transition(.opacity) 
+                        .onAppear(perform: hideSplashScreen)
+                    // First launch - show welcome screen with login button
+                } else if launchManager.isFirstLaunch {
+                    FirstLaunchWelcomeView(onLoginTapped: {
+                        launchManager.markAppAsLaunched()
+                    })
                     .transition(.blurReplace)
-                    .onAppear(perform: hideSplashScreen)
-                // First launch - show welcome screen with login button
-            } else if launchManager.isFirstLaunch {
-                FirstLaunchWelcomeView(onLoginTapped: {
-                    launchManager.markAppAsLaunched()
-                })
-                .transition(.blurReplace)
-                // Signed-in and has school --> show main content
-            } else if auth.isSignedIn && isAssignedToSchool {
-                ZStack {
+                    // Signed-in and has school --> show main content
+                } else if auth.isSignedIn && isAssignedToSchool {
                     if !didCompleteOnboarding {
                         WelcomeView()
                             .transition(.blurReplace)
@@ -62,14 +62,14 @@ struct MainContentView: View {
                         MainTabView()
                             .transition(.blurReplace)
                     }
+                } else if hasNoSchool {
+                    NotRegisteredView()
+                        .transition(.blurReplace)
+                } else if !auth.isSignedIn {
+                    // Not signed in --> show SignInView
+                    SignInView()
+                        .transition(.blurReplace)
                 }
-            } else if hasNoSchool {
-                NotRegisteredView()
-                    .transition(.blurReplace)
-            } else {
-                // Not signed in --> show SignInView
-                SignInView()
-                    .transition(.blurReplace)
             }
             
         }

--- a/Gradeva/Views/MainView.swift
+++ b/Gradeva/Views/MainView.swift
@@ -12,6 +12,7 @@ import FirebaseAuth
 struct MainContentView: View {
     @ObservedObject private var auth = AuthManager.shared
     @StateObject private var navManager = NavManager()
+    @State private var showSplashScreen = true
     
     var didCompleteOnboarding: Bool {
         auth.currentUser?.didCompleteOnboarding ?? false
@@ -25,12 +26,21 @@ struct MainContentView: View {
         !isAssignedToSchool && auth.isSignedIn
     }
     
+    private func hideSplashScreen() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            withAnimation {
+                showSplashScreen = false
+            }
+        }
+    }
+    
     var body: some View {
         NavigationStack(path: $navManager.paths) {
-            // Show splash screen while authentication is loading
-            if auth.isAuthLoading {
+            // Show splash screen on first launch for 1.5 seconds
+            if showSplashScreen {
                 SplashScreenView()
                     .transition(.blurReplace)
+                    .onAppear(perform: hideSplashScreen)
             // Signed-in  --> show HomeView
             } else if auth.isSignedIn && isAssignedToSchool {
                 if !didCompleteOnboarding {

--- a/Gradeva/Views/MainView.swift
+++ b/Gradeva/Views/MainView.swift
@@ -27,8 +27,12 @@ struct MainContentView: View {
     
     var body: some View {
         NavigationStack(path: $navManager.paths) {
+            // Show splash screen while authentication is loading
+            if auth.isAuthLoading {
+                SplashScreenView()
+                    .transition(.blurReplace)
             // Signed-in  --> show HomeView
-            if auth.isSignedIn && isAssignedToSchool {
+            } else if auth.isSignedIn && isAssignedToSchool {
                 if !didCompleteOnboarding {
                     WelcomeView()
                 } else {

--- a/Gradeva/Views/MainView.swift
+++ b/Gradeva/Views/MainView.swift
@@ -43,44 +43,13 @@ struct MainContentView: View {
                     .onAppear(perform: hideSplashScreen)
             // Signed-in  --> show HomeView
             } else if auth.isSignedIn && isAssignedToSchool {
-                if !didCompleteOnboarding {
-                    WelcomeView()
-                } else {
-                    TabView {
-                        HomeView()
-                            .tabItem {
-                                Label("Home", systemImage: "house")
-                                    .accessibilityLabel("Home tab")
-                                    .accessibilityHint("View dashboard and overview")
-                            }
-                        GradingView()
-                            .tabItem {
-                                Label("Grading", systemImage: "pencil")
-                                    .accessibilityLabel("Grading tab")
-                                    .accessibilityHint("Grade student exams and assignments")
-                            }
-                        AnalyticsView()
-                            .tabItem {
-                                Label("Analytics", systemImage: "chart.bar")
-                                    .accessibilityLabel("Analytics tab")
-                                    .accessibilityHint("View performance statistics and reports")
-                            }
-                        ProfileView()
-                            .tabItem {
-                                Label("Profile", systemImage: "person")
-                                    .accessibilityLabel("Profile tab")
-                                    .accessibilityHint("Manage your account and settings")
-                            }
-                    }
-                    .accessibilityElement(children: .contain)
-                    .accessibilityLabel("Main navigation tabs")
-                    .navigationDestination(for: NavPath.self) { path in
-                        switch path {
-                        case .settings:
-                            SettingsView()
-                        case .grading(let examId):
-                            GradingExamView(examId: examId)
-                        }
+                ZStack {
+                    if !didCompleteOnboarding {
+                        WelcomeView()
+                            .transition(.blurReplace)
+                    } else {
+                        MainTabView()
+                            .transition(.blurReplace)
                     }
                 }
             } else if hasNoSchool {

--- a/Gradeva/Views/MainView.swift
+++ b/Gradeva/Views/MainView.swift
@@ -19,6 +19,10 @@ struct MainContentView: View {
         auth.currentUser?.didCompleteOnboarding ?? false
     }
     
+    var didCompleteDemoOnboarding: Bool {
+        auth.currentUser?.didCompleteDemoOnboarding ?? false
+    }
+    
     var isAssignedToSchool: Bool {
         auth.currentUser?.schoolId != nil
     }
@@ -42,13 +46,13 @@ struct MainContentView: View {
                 SplashScreenView()
                     .transition(.blurReplace)
                     .onAppear(perform: hideSplashScreen)
-            // First launch - show welcome screen with login button
+                // First launch - show welcome screen with login button
             } else if launchManager.isFirstLaunch {
                 FirstLaunchWelcomeView(onLoginTapped: {
                     launchManager.markAppAsLaunched()
                 })
                 .transition(.blurReplace)
-            // Signed-in and has school --> show main content
+                // Signed-in and has school --> show main content
             } else if auth.isSignedIn && isAssignedToSchool {
                 ZStack {
                     if !didCompleteOnboarding {
@@ -61,9 +65,11 @@ struct MainContentView: View {
                 }
             } else if hasNoSchool {
                 NotRegisteredView()
+                    .transition(.blurReplace)
             } else {
                 // Not signed in --> show SignInView
                 SignInView()
+                    .transition(.blurReplace)
             }
             
         }

--- a/Gradeva/Views/Onboarding/Components/RegistrationStepView.swift
+++ b/Gradeva/Views/Onboarding/Components/RegistrationStepView.swift
@@ -1,0 +1,102 @@
+//
+//  RegistrationStepView.swift
+//  Gradeva
+//
+//  Created by Claude on 20/08/25.
+//
+
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct RegistrationStepView: View {
+    @StateObject private var registration = RegistrationManager()
+    @EnvironmentObject private var auth: AuthManager
+    
+    var registrationLink: String {
+        if let registrationId = registration.myRegistration?.id {
+            return "https://gradeva.muhammadramdan.com/register/\(registrationId)"
+        }
+        return "https://gradeva.muhammadramdan.com/not-found"
+    }
+    
+    func handleCopyLink() {
+        UIPasteboard.general.setValue(registrationLink, forPasteboardType: UTType.plainText.identifier)
+    }
+    
+    var body: some View {
+        VStack(spacing: 24) {
+            Spacer()
+            
+            // Header icon
+            Image(systemName: "building.2")
+                .font(.system(size: 60))
+                .foregroundColor(.accentColor)
+                .accessibilityHidden(true)
+            
+            // Title and description
+            VStack(spacing: 12) {
+                Text("School Registration")
+                    .font(.title2)
+                    .fontWeight(.bold)
+                    .accessibilityAddTraits(.isHeader)
+                
+                Text("To access Gradeva, you need to be registered with a school. Please share the link below with your school administrator.")
+                    .font(.body)
+                    .multilineTextAlignment(.center)
+                    .foregroundColor(.secondary)
+                    .accessibilityAddTraits(.isStaticText)
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("School Registration. To access Gradeva, you need to be registered with a school. Please share the link below with your school administrator.")
+            .accessibilityAddTraits(.isHeader)
+            
+            // Registration link section
+            VStack(spacing: 16) {
+                Text("Registration Link")
+                    .font(.headline)
+                    .accessibilityAddTraits(.isHeader)
+                
+                Button(action: handleCopyLink) {
+                    HStack(spacing: 12) {
+                        Text(registrationLink)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                            .font(.caption)
+                        
+                        Image(systemName: "document.on.document")
+                            .font(.system(size: 16))
+                            .accessibilityHidden(true)
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .padding(.horizontal, 16)
+                    .background(Color(.systemGray6))
+                    .foregroundColor(.primary)
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(Color(.systemGray4), lineWidth: 1)
+                    )
+                }
+                .accessibilityLabel("Copy registration link")
+                .accessibilityHint("Double tap to copy the registration link to clipboard")
+                .accessibilityAddTraits(.isButton)
+                .accessibilityValue(registrationLink)
+            }
+            
+            // Demo option note
+            Text("You can also try with demo data by tapping the \"Try Demo School\" below")
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .accessibilityAddTraits(.isStaticText)
+            
+            Spacer()
+        }
+    }
+}
+
+#Preview {
+    RegistrationStepView()
+        .environmentObject(AuthManager.shared)
+}

--- a/Gradeva/Views/Onboarding/NotRegisteredView.swift
+++ b/Gradeva/Views/Onboarding/NotRegisteredView.swift
@@ -12,7 +12,6 @@ struct NotRegisteredView: View {
     @StateObject private var registration = RegistrationManager()
     @EnvironmentObject private var auth: AuthManager
     
-    
     var registrationLink: String {
         if let registrationId = registration.myRegistration?.id {
             return "https://gradeva.muhammadramdan.com/register/\(registrationId)"
@@ -64,18 +63,24 @@ struct NotRegisteredView: View {
                     )
             )
             
-            Button(action: {
-                auth.signOut()
-            }) {
+            Button(action: auth.signOut) {
                 Text("Sign Out")
                     .fontWeight(.semibold)
-                    .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(Color.red)
-                    .foregroundColor(.white)
-                    .cornerRadius(8)
             }
-            .padding(.horizontal)
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(Color.red)
+            .foregroundColor(.white)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
+            
+            Button(action: registration.registerToDemo) {
+                Text("Try with Demo School")
+            }
+            .frame(maxWidth: .infinity)
+            .padding()
+            .background(Color.accentColor)
+            .foregroundStyle(.white)
+            .clipShape(RoundedRectangle(cornerRadius: 16))
         }
         .padding()
     }

--- a/Gradeva/Views/Onboarding/NotRegisteredView.swift
+++ b/Gradeva/Views/Onboarding/NotRegisteredView.swift
@@ -6,83 +6,214 @@
 //
 
 import SwiftUI
-import UniformTypeIdentifiers
 
 struct NotRegisteredView: View {
-    @StateObject private var registration = RegistrationManager()
     @EnvironmentObject private var auth: AuthManager
+    @State private var currentStep = 0
+    @State private var name: String = ""
+    @State private var isUpdatingUser = false
     
-    var registrationLink: String {
-        if let registrationId = registration.myRegistration?.id {
-            return "https://gradeva.muhammadramdan.com/register/\(registrationId)"
-        }
-        return "https://gradeva.muhammadramdan.com/register"
+    private let userServices = UserServices()
+    
+    private var canContinueFromName: Bool {
+        !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
     
-    func handleCopyLink() {
-        UIPasteboard.general.setValue(registrationLink, forPasteboardType: UTType.plainText.identifier)
+    private func nextStep() {
+        withAnimation {
+            currentStep += 1
+        }
+    }
+    
+    private func previousStep() {
+        withAnimation {
+            currentStep -= 1
+        }
+    }
+    
+    private func updateUserAndContinue(updatedUser: AppUser) {
+        isUpdatingUser = true
+        
+        userServices.updateUser(user: updatedUser) { result in
+            DispatchQueue.main.async {
+                self.isUpdatingUser = false
+                switch result {
+                case .success:
+                    // Update the auth manager with the new user data
+                    self.auth.updateCurrentUser(updatedUser)
+                    self.nextStep()
+                case .failure(let error):
+                    print("Failed to update user: \(error.localizedDescription)")
+                    // Still continue to next step even if save fails
+                    self.nextStep()
+                }
+            }
+        }
+    }
+    
+    private func saveNameAndContinue() {
+        guard let currentUser = auth.currentUser else { return }
+        
+        let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        let updatedUser = currentUser.copy(displayName: trimmedName)
+        updateUserAndContinue(updatedUser: updatedUser)
+    }
+    
+    
+    private func getNextAction() {
+        switch currentStep {
+        case 0:
+            nextStep()
+        case 1:
+            if canContinueFromName && !isUpdatingUser {
+                saveNameAndContinue()
+            }
+        case 2:
+            // Try demo school on finish
+            RegistrationManager().registerToDemo()
+        default:
+            break
+        }
     }
     
     var body: some View {
         VStack {
-            Image(systemName: "info.circle")
-                .resizable()
-                .frame(width: 30, height: 30)
-                .foregroundStyle(Color.accentColor)
-            Text("Hi there! It seems you do not belong to any school")
-                .multilineTextAlignment(.center)
-            
-            Spacer()
-                .frame(height: 30)
-            
-            Divider()
-            
-            Spacer()
-                .frame(height: 30)
-            
-            Text("Copy this link and give to your school administrator")
-                .multilineTextAlignment(.center)
-            
-            Button(action: handleCopyLink) {
-                HStack {
-                    Text(registrationLink)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                    Image(systemName: "document.on.document")
-                        .resizable()
-                        .frame(width: 20, height: 24)
+            // Header with step indicator
+            HStack(spacing: 8) {
+                ForEach(0..<3, id: \.self) { index in
+                    Circle()
+                        .fill(index <= currentStep ? Color.accentColor : Color.gray.opacity(0.3))
+                        .frame(width: 8, height: 8)
+                        .scaleEffect(index == currentStep ? 1.2 : 1.0)
                 }
             }
-            .padding()
-            .background(
-                RoundedRectangle(cornerRadius: 8)
-                    .fill(Color(.systemBackground))
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Registration progress")
+            .accessibilityValue("Step \(currentStep + 1) of 3")
+            .padding(.top)
+            
+            // Step content with sliding animation
+            ZStack {
+                switch currentStep {
+                case 0:
+                    WelcomeStepView()
+                        .transition(.blurReplace)
+                        .padding(.horizontal, 24)
+                case 1:
+                    NameStepView(name: $name)
+                        .transition(.blurReplace)
+                        .padding(.horizontal, 24)
+                case 2:
+                    RegistrationStepView()
+                        .transition(.blurReplace)
+                        .padding(.horizontal, 24)
+                default:
+                    EmptyView()
+                }
+            }
+            .frame(maxHeight: .infinity)
+            
+            // Bottom navigation
+            VStack(spacing: 12) {
+                // Back button (outlined)
+                
+                Button(action: previousStep) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "chevron.left")
+                            .accessibilityHidden(true)
+                        Text("Back")
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical)
                     .overlay(
-                        RoundedRectangle(cornerRadius: 8)
-                            .stroke(Color(.systemGray4), lineWidth: 1)
+                        RoundedRectangle(cornerRadius: 16)
+                            .stroke(Color.accentColor, lineWidth: 1)
                     )
-            )
-            
-            Button(action: auth.signOut) {
-                Text("Sign Out")
-                    .fontWeight(.semibold)
+                }
+                .transition(.blurReplace)
+                .opacity(currentStep == 0 ? 0 : 1)
+                .disabled(currentStep == 0)
+                .accessibilityHidden(currentStep == 0)
+                .accessibilityLabel("Back")
+                .accessibilityHint("Double tap to go to previous step")
+                .accessibilityAddTraits(.isButton)
+                .frame(minHeight: 44)
+                
+                
+                // Main button (show for all steps)
+                Button(action: getNextAction) {
+                    HStack {
+                        if isUpdatingUser && currentStep == 1 {
+                            ProgressView()
+                                .accessibilityLabel("Updating profile")
+                        } else {
+                            Text(buttonTitle)
+                            Image(systemName: buttonIcon)
+                                .accessibilityHidden(true)
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical)
+                    .background(buttonEnabled ? Color.accentColor : Color.gray.opacity(0.3))
+                    .foregroundStyle(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+                    .transition(.opacity)
+                }
+                .disabled(!buttonEnabled)
+                .accessibilityLabel(buttonTitle)
+                .accessibilityHint(buttonHint)
+                .accessibilityAddTraits(.isButton)
+                .accessibilityValue(buttonEnabled ? "" : "Disabled")
+                .frame(minHeight: 44)
+                
             }
-            .frame(maxWidth: .infinity)
-            .padding()
-            .background(Color.red)
-            .foregroundColor(.white)
-            .clipShape(RoundedRectangle(cornerRadius: 16))
-            
-            Button(action: registration.registerToDemo) {
-                Text("Try with Demo School")
-            }
-            .frame(maxWidth: .infinity)
-            .padding()
-            .background(Color.accentColor)
-            .foregroundStyle(.white)
-            .clipShape(RoundedRectangle(cornerRadius: 16))
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("Registration navigation")
+            .padding(.horizontal, 24)
+            .padding(.bottom, 40)
         }
-        .padding()
+        .ignoresSafeArea(.keyboard)
+        .onAppear {
+            // Prefill name field with user's current display name
+            if name.isEmpty, let displayName = auth.currentUser?.displayName, !displayName.isEmpty {
+                name = displayName
+            }
+        }
+    }
+    
+    private var buttonTitle: String {
+        switch currentStep {
+        case 0: return "Get Started"
+        case 1: return "Continue"
+        case 2: return "Try Demo School"
+        default: return "Continue"
+        }
+    }
+    
+    private var buttonIcon: String {
+        switch currentStep {
+        case 0, 1: return "arrow.right"
+        case 2: return "play.circle"
+        default: return "arrow.right"
+        }
+    }
+    
+    private var buttonEnabled: Bool {
+        switch currentStep {
+        case 0: return true
+        case 1: return canContinueFromName && !isUpdatingUser
+        case 2: return true
+        default: return false
+        }
+    }
+    
+    private var buttonHint: String {
+        switch currentStep {
+        case 0: return "Double tap to start the registration process"
+        case 1: return canContinueFromName ? "Double tap to continue to registration instructions" : "Enter your name to continue"
+        case 2: return "Double tap to register with demo school and start using the app"
+        default: return "Double tap to continue"
+        }
     }
 }
 

--- a/Gradeva/Views/Onboarding/WelcomeView.swift
+++ b/Gradeva/Views/Onboarding/WelcomeView.swift
@@ -65,104 +65,102 @@ struct WelcomeView: View {
     }
     
     var body: some View {
-        GeometryReader { geometry in
-            VStack {
-                // Header with step indicator
-                HStack(spacing: 8) {
-                    ForEach(0..<3, id: \.self) { index in
-                        Circle()
-                            .fill(index <= currentStep ? Color.accentColor : Color.gray.opacity(0.3))
-                            .frame(width: 8, height: 8)
-                            .scaleEffect(index == currentStep ? 1.2 : 1.0)
-                    }
+        VStack {
+            // Header with step indicator
+            HStack(spacing: 8) {
+                ForEach(0..<3, id: \.self) { index in
+                    Circle()
+                        .fill(index <= currentStep ? Color.accentColor : Color.gray.opacity(0.3))
+                        .frame(width: 8, height: 8)
+                        .scaleEffect(index == currentStep ? 1.2 : 1.0)
                 }
-                .accessibilityElement(children: .combine)
-                .accessibilityLabel("Onboarding progress")
-                .accessibilityValue("Step \(currentStep + 1) of 3")
-                
-                // Step content with sliding animation
-                ZStack {
-                    switch currentStep {
-                    case 0:
-                        WelcomeStepView()
-                            .transition(.blurReplace)
-                            .padding(.horizontal, 24)
-                    case 1:
-                        NameStepView(name: $name)
-                            .transition(.blurReplace)
-                            .padding(.horizontal, 24)
-                    case 2:
-                        SubjectsStepView(selectedSubjects: $selectedSubjects)
-                            .environmentObject(subjectsManager)
-                            .transition(.blurReplace)
-                            // padding set internally
-                    default:
-                        EmptyView()
-                    }
+            }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Onboarding progress")
+            .accessibilityValue("Step \(currentStep + 1) of 3")
+            .padding(.top)
+            
+            // Step content with sliding animation
+            ZStack {
+                switch currentStep {
+                case 0:
+                    WelcomeStepView()
+                        .transition(.blurReplace)
+                        .padding(.horizontal, 24)
+                case 1:
+                    NameStepView(name: $name)
+                        .transition(.blurReplace)
+                        .padding(.horizontal, 24)
+                case 2:
+                    SubjectsStepView(selectedSubjects: $selectedSubjects)
+                        .environmentObject(subjectsManager)
+                        .transition(.blurReplace)
+                        // padding set internally
+                default:
+                    EmptyView()
                 }
-                .frame(maxHeight: .infinity)
-                
-                // Bottom navigation
-                VStack(spacing: 12) {
-                    // Back button (outlined)
-                    if currentStep > 0 {
-                        Button(action: previousStep) {
-                            HStack(spacing: 8) {
-                                Image(systemName: "chevron.left")
-                                    .accessibilityHidden(true)
-                                Text("Back")
-                            }
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical)
-                            .overlay(
-                                RoundedRectangle(cornerRadius: 16)
-                                    .stroke(Color.accentColor, lineWidth: 1)
-                            )
-                        }
-                        .transition(.opacity)
-                        .disabled(subjectsManager.isClaimingSubjects)
-                        .accessibilityLabel("Back")
-                        .accessibilityHint("Double tap to go to previous onboarding step")
-                        .accessibilityAddTraits(.isButton)
-                    }
-                    
-                    // Main button
-                    Button(action: getNextAction) {
-                        HStack {
-                            if subjectsManager.isClaimingSubjects && currentStep == 2 {
-                                ProgressView()
-                                    .accessibilityLabel("Setting up your account")
-                            } else {
-                                Text(buttonTitle)
-                                Image(systemName: buttonIcon)
-                                    .accessibilityHidden(true)
-                            }
+            }
+            .frame(maxHeight: .infinity)
+            
+            // Bottom navigation
+            VStack(spacing: 12) {
+                // Back button (outlined)
+                if currentStep > 0 {
+                    Button(action: previousStep) {
+                        HStack(spacing: 8) {
+                            Image(systemName: "chevron.left")
+                                .accessibilityHidden(true)
+                            Text("Back")
                         }
                         .frame(maxWidth: .infinity)
                         .padding(.vertical)
-                        .background(buttonEnabled ? Color.accentColor : Color.gray.opacity(0.3))
-                        .foregroundStyle(.white)
-                        .clipShape(RoundedRectangle(cornerRadius: 16))
-                        .transition(.opacity)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 16)
+                                .stroke(Color.accentColor, lineWidth: 1)
+                        )
                     }
-                    .disabled(!buttonEnabled || subjectsManager.isClaimingSubjects)
-                    .accessibilityLabel(buttonTitle)
-                    .accessibilityHint(buttonHint)
+                    .transition(.opacity)
+                    .disabled(subjectsManager.isClaimingSubjects)
+                    .accessibilityLabel("Back")
+                    .accessibilityHint("Double tap to go to previous onboarding step")
                     .accessibilityAddTraits(.isButton)
-                    .accessibilityValue(buttonEnabled ? "" : "Disabled")
-                    
-                    // Error message
-                    if let errorMessage = subjectsManager.errorMessage {
-                        InlineErrorView(message: errorMessage)
-                            .transition(.opacity)
-                    }
                 }
-                .accessibilityElement(children: .contain)
-                .accessibilityLabel("Onboarding navigation")
-                .padding(.horizontal, 24)
+                
+                // Main button
+                Button(action: getNextAction) {
+                    HStack {
+                        if subjectsManager.isClaimingSubjects && currentStep == 2 {
+                            ProgressView()
+                                .accessibilityLabel("Setting up your account")
+                        } else {
+                            Text(buttonTitle)
+                            Image(systemName: buttonIcon)
+                                .accessibilityHidden(true)
+                        }
+                    }
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical)
+                    .background(buttonEnabled ? Color.accentColor : Color.gray.opacity(0.3))
+                    .foregroundStyle(.white)
+                    .clipShape(RoundedRectangle(cornerRadius: 16))
+                    .transition(.opacity)
+                }
+                .disabled(!buttonEnabled || subjectsManager.isClaimingSubjects)
+                .accessibilityLabel(buttonTitle)
+                .accessibilityHint(buttonHint)
+                .accessibilityAddTraits(.isButton)
+                .accessibilityValue(buttonEnabled ? "" : "Disabled")
+                
+                // Error message
+                if let errorMessage = subjectsManager.errorMessage {
+                    InlineErrorView(message: errorMessage)
+                        .transition(.opacity)
+                }
             }
-            .padding(.bottom, max(40, geometry.safeAreaInsets.bottom + 20))
-            .padding(.top)
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("Onboarding navigation")
+            .padding(.horizontal, 24)
+            .padding(.bottom, 40)
         }
         .ignoresSafeArea(.keyboard)
     }

--- a/Gradeva/Views/SplashScreenView.swift
+++ b/Gradeva/Views/SplashScreenView.swift
@@ -1,0 +1,41 @@
+//
+//  SplashScreenView.swift
+//  Gradeva
+//
+//  Created by Claude Code on 20/08/25.
+//
+
+import SwiftUI
+
+struct SplashScreenView: View {
+    var body: some View {
+        ZStack {
+            Color.accentColor
+                .ignoresSafeArea()
+            
+            VStack(spacing: 30) {
+                Image(systemName: "graduationcap.fill")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 80, height: 80)
+                    .foregroundColor(.white)
+                
+                Text("Gradeva")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                    .foregroundColor(.white)
+                
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                    .controlSize(.large)
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Gradeva app loading")
+        .accessibilityValue("Please wait while the app loads")
+    }
+}
+
+#Preview {
+    SplashScreenView()
+}


### PR DESCRIPTION
This pull request introduces a demo mode for users to try the app without full registration, improves the onboarding experience, and adds a splash screen during authentication loading. The main changes are grouped below by theme.

**Demo Mode & Onboarding Enhancements:**

* Added a `registerToDemo` method to `RegistrationManager`, allowing users to register to a demo school account.
* Updated `NotRegisteredView` to include a "Try with Demo School" button, which triggers the demo registration flow.
* Improved the "Sign Out" button styling in `NotRegisteredView` for better UI consistency.

**Authentication & User Experience Improvements:**

* Added a new `SplashScreenView` that displays while authentication is loading, providing a smoother user experience.
* Updated `MainContentView` to show the splash screen when `auth.isAuthLoading` is true, using a blur transition for a polished effect.
* Added animation to the loading state change in `AuthManager` for a smoother transition.