### PR TITLE
add batch firestore rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -50,6 +50,12 @@ service cloud.firestore {
       allow read: if belongsToSchool(schoolId) || isSchoolAdmin(schoolId);
       allow write: if isSchoolAdmin(schoolId);
 
+      // Batches subcollection - school members can read, school admins can write
+      match /batches/{batchId} {
+        allow read: if belongsToSchool(schoolId) || isSchoolAdmin(schoolId);
+        allow write: if isSchoolAdmin(schoolId);
+      }
+
       // Students subcollection - school members can read, school admins can write
       match /students/{studentId} {
         allow write: if isSchoolAdmin(schoolId);


### PR DESCRIPTION
This pull request updates the Firestore security rules to add access control for the `batches` subcollection under each school. The main change ensures that only school members can read batch data, while only school admins can write to it.

**Access control updates:**

* Added rules for the `batches` subcollection so that school members can read batch documents, and only school admins can write to them.